### PR TITLE
Fix upload path with no prefix

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -21,5 +21,7 @@
         "lukewestby/elm-string-interpolate": "1.0.4 <= v < 2.0.0",
         "rtfeldman/elm-iso8601-date-strings": "1.1.2 <= v < 2.0.0"
     },
-    "test-dependencies": {}
+    "test-dependencies": {
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
+    }
 }

--- a/src/S3.elm
+++ b/src/S3.elm
@@ -1,6 +1,7 @@
 module S3 exposing
     ( Config, config, withPrefix, withSuccessActionStatus, withAwsS3Host, withAcl
     , FileData, Response, uploadFile, uploadFileTask
+    , buildUploadKey
     )
 
 {-| This package helps make uploading file to [Amazon S3](https://aws.amazon.com/s3/) quick and easy.
@@ -162,10 +163,7 @@ uploadFileTask fileData ((Internals.Config record) as qualConfig) =
                             ]
 
                     key =
-                        interpolate "{0}/{1}"
-                            [ record.prefix
-                            , fileData.fileName
-                            ]
+                        buildUploadKey record.prefix fileData.fileName
 
                     parts =
                         Internals.generatePolicy key
@@ -234,6 +232,34 @@ uploadFileHttpTask { url, file, parts, key, bucket } =
                 )
         , timeout = Nothing
         }
+
+
+buildUploadKey : String -> String -> String
+buildUploadKey prefix fileName =
+    let
+        stripLeadingSlashes s =
+            if String.startsWith "/" s then
+                String.dropLeft 1 s
+
+            else
+                s
+
+        stripTrailingSlashes s =
+            if String.endsWith "/" s then
+                String.dropRight 1 s
+
+            else
+                s
+
+        normalize =
+            stripLeadingSlashes >> stripTrailingSlashes
+    in
+    case prefix of
+        "" ->
+            fileName
+
+        _ ->
+            normalize prefix ++ "/" ++ fileName
 
 
 

--- a/tests/Suite.elm
+++ b/tests/Suite.elm
@@ -1,0 +1,19 @@
+module Suite exposing (suite)
+
+import Expect exposing (Expectation)
+import S3
+import Test exposing (Test, describe, test)
+
+
+suite : Test
+suite =
+    describe "Session"
+        [ test "Key building: no prefix" <|
+            \_ -> Expect.equal (S3.buildUploadKey "" "bar") "bar"
+        , test "Key building: plain prefix" <|
+            \_ -> Expect.equal (S3.buildUploadKey "foo" "bar") "foo/bar"
+        , test "Key building: prefix with a leading slash" <|
+            \_ -> Expect.equal (S3.buildUploadKey "/foo" "bar") "foo/bar"
+        , test "Key building: prefix with leading & trailing slashes" <|
+            \_ -> Expect.equal (S3.buildUploadKey "/foo/" "bar") "foo/bar"
+        ]


### PR DESCRIPTION
This should fix #2, mostly by just making sure there are no extra slashes introduced when dealing with path prefixes. The slash stripping is a bit cumbersome, but I could not think of a nicer way to do it. (In the worst case we can always leave the smart slash stripping out and just handle the empty prefix correctly.)